### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [macos-latest, windows-latest]
 
     strategy:
       matrix:

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -3,8 +3,40 @@ name: xdpm CI
 on: [push]
 
 jobs:
-  build:
-    runs-on: [macos-latest, windows-latest]
+  mac:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm link
+    - run: xdpm -v
+    - run: xdpm validate
+      continue-on-error: true
+    - run: xdpm package
+      continue-on-error: true
+    - run: xdpm install
+      continue-on-error: true
+    - run: git clone https://github.com/AdobeXD/plugin-samples.git
+    - run: xdpm validate
+      working-directory: ./plugin-samples/quick-start
+    - run: xdpm package
+      working-directory: ./plugin-samples/quick-start
+    - run: echo "{}" > ./manifest.json
+      working-directory: ./plugin-samples/quick-start
+    - run: xdpm validate
+      working-directory: ./plugin-samples/quick-start
+      continue-on-error: true
+
+  windows:
+    runs-on: windows-latest
 
     strategy:
       matrix:

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -22,6 +22,7 @@ jobs:
       continue-on-error: true
     - run: xdpm package
       continue-on-error: true
+    - run: mkdir -p /Users/runner/Library/Application\ Support/Adobe/Adobe\ XD
     - run: xdpm install
       continue-on-error: true
     - run: git clone https://github.com/AdobeXD/plugin-samples.git

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -56,6 +56,7 @@ jobs:
       continue-on-error: true
     - run: xdpm package
       continue-on-error: true
+    - run: mkdir -p /Users/runner/Library/Application\ Support/Adobe/Adobe\ XD
     - run: xdpm install
       continue-on-error: true
     - run: git clone https://github.com/AdobeXD/plugin-samples.git

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -56,7 +56,7 @@ jobs:
       continue-on-error: true
     - run: xdpm package
       continue-on-error: true
-    - run: mkdir -p /Users/runner/Library/Application\ Support/Adobe/Adobe\ XD
+    - run: md C:\Users\runneradmin\AppData\Local\Packages\Adobe.CC.XD_adky2gkssdxte\LocalState
     - run: xdpm install
       continue-on-error: true
     - run: git clone https://github.com/AdobeXD/plugin-samples.git

--- a/lib/manifestSchema.js
+++ b/lib/manifestSchema.js
@@ -1,5 +1,5 @@
 const manifestScema = {
-    required: ["id", "name", "version", "host", "uiEntryPoints"],
+    required: ["id", "name", "version", "icons", "host", "uiEntryPoints"],
     properties: {
         id: {
             type: "string",
@@ -20,6 +20,7 @@ const manifestScema = {
             minItems: 2,
             uniqueItems: true,
             items: {
+                type: "object",
                 required: ["path", "width", "height"],
                 properties: {
                     path: {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -24,23 +24,29 @@ function validate(manifest, { root, id } = {}) {
     let errors = [];
     var validate = ajv.compile(manifestScema);
     var valid = validate(manifest);
+    
     if ( id && manifest.id !== id ) {
         errors.push(
             `F1001: Manifest 'id' does not match expected id. Saw '${manifest.id}', expected '${id}'.`
         );
     }
+
     if (!valid) {
         errors = validate.errors.map(
             e => `${e.dataPath} (${JSON.stringify(e.params)}) -> ${e.message} `
         );
     }
-    manifest.icons.forEach((icon, idx) => {
-        if (!fs.existsSync(path.join(root || ".", icon.path))) {
-            errors.push(
-                `W2004: Icon ${idx} has path ${icon.path}, but no icon was found there.`
-            );
-        }
-    });
+
+    if (manifest.icons) {
+        manifest.icons.forEach((icon, idx) => {
+            if (!fs.existsSync(path.join(root || ".", icon.path))) {
+                errors.push(
+                    `W2004: Icon ${idx} has path ${icon.path}, but no icon was found there.`
+                );
+            }
+        });
+    }
+
     return errors;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/xdpm",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I did a little hacking on the actions you set up:
https://github.com/ashryanbeats/xdpm/blob/github-actions/.github/workflows/cli-test.yml

Here's the result:
https://github.com/ashryanbeats/xdpm/runs/346161827

You'll note that there are no more failure annotations. This may not be the final result we're looking for, but I'm hoping this is helpful.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/AdobeXD/xdpm/pull/35

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

In this fork, the changes worth noting:

- [action] Now running jobs on Mac and Win
- [action] Ensuring xdpm install action doesn't fail due to non-existent target dirs by using `mkdir/md`
- [lib/validate.js] Ensuring xdpm validate action doesn't fail by checking if `.icons` property exists before invoking `.forEach`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
